### PR TITLE
fix Field 'name' in type 'AppServerInfo' is undefined error in javascript

### DIFF
--- a/src/models/application.js
+++ b/src/models/application.js
@@ -36,7 +36,7 @@ const dataQuery = `
     }
     getServerThroughput(applicationId: $applicationId, duration: $duration, topN: 10) {
       key: id
-      name
+      osName
       callsPerSec
     }
     getApplicationTopology(applicationId: $applicationId, duration: $duration) {

--- a/src/routes/Server/Server.js
+++ b/src/routes/Server/Server.js
@@ -87,7 +87,7 @@ export default class Server extends PureComponent {
                   query SearchServer($keyword: String!, $duration: Duration!) {
                     searchServer(keyword: $keyword, duration: $duration) {
                       key: id
-                      name
+                      osName
                       host
                       pid
                       ipv4

--- a/src/routes/Server/Server.js
+++ b/src/routes/Server/Server.js
@@ -111,7 +111,7 @@ export default class Server extends PureComponent {
               <Description term="Host Name">{serverInfo.host}</Description>
               <Description term="IPv4">{serverInfo.ipv4 ? serverInfo.ipv4.join() : ''}</Description>
               <Description term="Process Id">{serverInfo.pid}</Description>
-              <Description term="OS">{serverInfo.name}</Description>
+              <Description term="OS">{serverInfo.osName}</Description>
             </DescriptionList>
           </Card>
           <Row gutter={24}>


### PR DESCRIPTION
in web ui menu "Server",it throw an exception that is
```
Validation error of type FieldUndefined: Field 'name' in type 'AppServerInfo' is undefined
```
so i trace it in client js and server,i found that in this url
`http://localhost:8080/api/server/search`  as same as `http://localhost:8080/api/application` it's response is
```
{
    "errors": [
        {
            "message": "Validation error of type FieldUndefined: Field 'name' in type 'AppServerInfo' is undefined"
        }
    ]
}
```
continue, this is producted in Graphql in server-side,the `server-layer.graphql` definition of `AppServerInfo` is
```
type AppServerInfo {
    id: ID!
    osName: String!
    applicationId: Int!
    applicationCode: String
    callsPerSec: Int!
    host: String
    pid: Int
    ipv4: [String!]!
}
```
but in javascript.the field is `name` ,see `Server.js`,that is
```
 query={`
                  query SearchServer($keyword: String!, $duration: Duration!) {
                    searchServer(keyword: $keyword, duration: $duration) {
                      key: id
                      name
                      host
                      pid
                      ipv4
                      applicationCode
                    }
                  }
                `}
```

the field is `name`,not 'osName' in server's graphql definition,so this error occur.
In summary, the data structure of the server and client are inconsistent