### PR TITLE
Fix trace field start time error

### DIFF
--- a/src/components/TraceTable/index.js
+++ b/src/components/TraceTable/index.js
@@ -80,7 +80,7 @@ class TraceTable extends PureComponent {
       {
         title: 'StartTime',
         render: (text, record) => {
-          return moment(record.startTime).format('YYYY-MM-DD HH:mm:ss.SSS');
+          return moment(record.start).format('YYYY-MM-DD HH:mm:ss.SSS');
         },
       },
       {

--- a/src/components/TraceTable/index.js
+++ b/src/components/TraceTable/index.js
@@ -80,7 +80,7 @@ class TraceTable extends PureComponent {
       {
         title: 'StartTime',
         render: (text, record) => {
-          return moment(record.start).format('YYYY-MM-DD HH:mm:ss.SSS');
+          return moment(parseInt(record.start, 10)).format('YYYY-MM-DD HH:mm:ss.SSS');
         },
       },
       {


### PR DESCRIPTION
in trace menu, the traceTable shows trace via /trace api and repsonse is 
```json
{
    "data": {
        "queryBasicTraces": {
            "traces": [
                {
                    "key": "6.63.15232477826870000",
                    "operationName": "hello",
                    "duration": 230,
                    "start": "1523247782695",
                    "isError": false,
                    "traceIds": [
                        "6.63.15232477826880001"
                    ]
                }
            ],
            "total": 4
        }
    }
}
```

but in client javascript,the `startTime` read `record.startTime`,However, the right field name is `start` and the type is timestamp and string ,so i fix it use 
```
parseInt(record.start, 10)
```