### PR TITLE
Fix Alarm Link

### DIFF
--- a/src/routes/Topology/Topology.js
+++ b/src/routes/Topology/Topology.js
@@ -97,7 +97,7 @@ export default class Topology extends PureComponent {
     return [
       <Icon type="appstore" onClick={() => redirect(this.props.history, '/monitor/application', { key: appInfo.id, label: appInfo.name })} />,
       <Icon type="exception" onClick={() => redirect(this.props.history, '/trace', { key: appInfo.id, label: appInfo.name })} />,
-      appInfo.isAlarm ? <Icon type="bell" onClick={() => redirect(this.props.history, '/alarm')} /> : null,
+      appInfo.isAlarm ? <Icon type="bell" onClick={() => redirect(this.props.history, '/monitor/alarm')} /> : null,
     ];
   }
   render() {


### PR DESCRIPTION
The `Alarm` link is invalid. Click the `Alarm` icon will redirect to the 404 page