### PR TITLE
Fix Trace search time is null ,there is an error

### DIFF
--- a/src/routes/Trace/TraceSearch.js
+++ b/src/routes/Trace/TraceSearch.js
@@ -85,7 +85,9 @@ export default class Trace extends PureComponent {
       const condition = { ...fieldsValue };
       delete condition['range-time-picker'];
       const rangeTime = fieldsValue['range-time-picker'];
-      const duration = generateDuration({ from: () => rangeTime[0], to: () => rangeTime[1] });
+      const duration = rangeTime && rangeTime.length ?
+        generateDuration({ from: () => rangeTime[0], to: () => rangeTime[1] }) :
+        this.getDefaultDuration();
       dispatch({
         type: 'trace/saveVariables',
         payload: {

--- a/src/routes/Trace/TraceSearch.js
+++ b/src/routes/Trace/TraceSearch.js
@@ -85,9 +85,7 @@ export default class Trace extends PureComponent {
       const condition = { ...fieldsValue };
       delete condition['range-time-picker'];
       const rangeTime = fieldsValue['range-time-picker'];
-      const duration = rangeTime && rangeTime.length ?
-        generateDuration({ from: () => rangeTime[0], to: () => rangeTime[1] }) :
-        this.getDefaultDuration();
+      const duration = generateDuration({ from: () => rangeTime[0], to: () => rangeTime[1] });
       dispatch({
         type: 'trace/saveVariables',
         payload: {
@@ -212,7 +210,12 @@ export default class Trace extends PureComponent {
     return (
       <Form onSubmit={this.handleSearch} layout="vertical">
         <FormItem label="Time Range">
-          {getFieldDecorator('range-time-picker')(
+          {getFieldDecorator('range-time-picker', {
+            rules: [{
+              required: true,
+              message: 'Please select the correct date',
+            }],
+          })(
             <RangePicker
               showTime
               disabledDate={current => current && current.valueOf() >= Date.now()}


### PR DESCRIPTION
If Trace search  time is null ,there is an error.
1.  so be compatible with this error
2. delete the time, we can get the newest trace instead of refresh the page to get. it is not convenient for end users now if user want to get the newest trace data.

![image](https://user-images.githubusercontent.com/11530760/39739297-c3dbfec6-52c2-11e8-9e4a-442dcf5a0a86.png)
