### PR TITLE
Optimization: description word-break

### DIFF
--- a/src/components/DescriptionList/index.less
+++ b/src/components/DescriptionList/index.less
@@ -50,6 +50,7 @@
   }
 
   .detail {
+    word-break: break-all;
     line-height: 22px;
     width: 100%;
     padding-bottom: 16px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10150229/51239193-a9325800-19b3-11e9-8746-9172b67fc3b3.png)
It would be better to increase the break here.